### PR TITLE
Remove Singleton Pattern

### DIFF
--- a/src/app/api.py
+++ b/src/app/api.py
@@ -219,6 +219,6 @@ if not is_production_environment():
         response_model=DeleteCacheOutput,
     )
     def delete_cache(reset_input: DeleteCacheInput):
-        cache_manager = CacheManager.get_instance()
+        cache_manager = CacheManager()
         row_count = cache_manager.reset_cache(reset_input.domain)
         return {"deleted_rows": row_count}

--- a/src/cache/cache_manager.py
+++ b/src/cache/cache_manager.py
@@ -3,7 +3,6 @@ import logging
 import time
 
 from app.models import Explanation, StarCase
-from core.website_manager import Singleton
 from db.db import get_top_level_domains, read_cached_values_by_feature, reset_cache
 from lib.constants import ACCESSIBILITY, EXPLANATION, SECONDS_PER_DAY, STAR_CASE, TIME_REQUIRED, TIMESTAMP, VALUES
 from lib.logger import get_logger
@@ -12,7 +11,6 @@ from lib.timing import get_utc_now, global_start
 from lib.tools import get_mean, get_unique_list
 
 
-@Singleton
 class CacheManager:
     _logger: logging.Logger
     _domain: str

--- a/src/core/metadata_manager.py
+++ b/src/core/metadata_manager.py
@@ -9,7 +9,7 @@ from app.communication import Message
 from app.models import Explanation
 from cache.cache_manager import CacheManager
 from core.metadata_base import MetadataBase
-from core.website_manager import Singleton, WebsiteData
+from core.website_manager import WebsiteData
 from db.db import create_cache_entry
 from features.accessibility import Accessibility
 from features.cookies import Cookies
@@ -39,7 +39,6 @@ from lib.logger import get_logger
 from lib.timing import get_utc_now, global_start
 
 
-@Singleton
 class MetadataManager:
     def __init__(self) -> None:
         self._logger = get_logger()

--- a/src/core/website_manager.py
+++ b/src/core/website_manager.py
@@ -146,21 +146,3 @@ class WebsiteData:
             extensions=extract_extensions(raw_links=raw_links),
             values=[],
         )
-
-
-class Singleton:
-    _instance = None
-
-    def __init__(self, cls) -> None:
-        self._class = cls
-
-    def get_instance(self):
-        if self._instance is None:
-            self._instance = self._class()
-        return self._instance
-
-    def __call__(self) -> NoReturn:
-        raise TypeError("Singletons must only be accessed through `get_instance()`.")
-
-    def __instancecheck__(self, inst) -> bool:
-        return isinstance(inst, self._class)

--- a/src/manager.py
+++ b/src/manager.py
@@ -27,7 +27,7 @@ class Manager:
 
         self._create_api()
 
-        self.metadata_manager = MetadataManager.get_instance()
+        self.metadata_manager = MetadataManager()
 
         self.run_loop = True
 

--- a/tests/unit/cache_manager_test.py
+++ b/tests/unit/cache_manager_test.py
@@ -9,13 +9,9 @@ from lib.constants import ACCESSIBILITY, EXPLANATION, STAR_CASE, TIMESTAMP, VALU
 from lib.timing import get_utc_now
 
 
-@pytest.fixture
-def cache_manager(mocker):
-    with mock.patch("cache.cache_manager.get_logger"):
-        with mock.patch("cache.cache_manager.CacheManager._class._prepare_cache_manager"):
-            manager = CacheManager.get_instance()
-
-    return manager
+@pytest.fixture()
+def cache() -> CacheManager:
+    return CacheManager()
 
 
 """
@@ -23,27 +19,14 @@ def cache_manager(mocker):
 """
 
 
-def test_init(mocker):
-    with mock.patch("cache.cache_manager.get_logger"):
-        with mock.patch("cache.cache_manager.CacheManager._class._prepare_cache_manager") as prepare_cache_manager:
-            manager = CacheManager.get_instance()
-            assert manager._logger.debug.call_count == 1
-            assert prepare_cache_manager.call_count == 1
-
-
-"""
---------------------------------------------------------------------------------
-"""
-
-
-def test_is_host_predefined(cache_manager: CacheManager):
-    assert cache_manager.is_host_predefined() is False
+def test_is_host_predefined(cache: CacheManager):
+    assert cache.is_host_predefined() is False
 
     test_host = "test_host"
-    cache_manager._hosts = [test_host]
-    cache_manager.domain = test_host
+    cache._hosts = [test_host]
+    cache.domain = test_host
 
-    assert cache_manager.is_host_predefined()
+    assert cache.is_host_predefined()
 
 
 """
@@ -51,16 +34,16 @@ def test_is_host_predefined(cache_manager: CacheManager):
 """
 
 
-def test_is_enough_cached_data_present(cache_manager: CacheManager):
+def test_is_enough_cached_data_present(cache: CacheManager):
     cache_entries = [f'{{"timestamp": {get_utc_now()}}}'] * 1
     with mock.patch("cache.cache_manager.read_cached_values_by_feature") as read_cache:
         read_cache.return_value = cache_entries
-        assert cache_manager.is_enough_cached_data_present(ACCESSIBILITY) is False
+        assert cache.is_enough_cached_data_present(ACCESSIBILITY) is False
 
     cache_entries = [f'{{"timestamp": {get_utc_now()}}}'] * 5
     with mock.patch("cache.cache_manager.read_cached_values_by_feature") as read_cache:
         read_cache.return_value = cache_entries
-        assert cache_manager.is_enough_cached_data_present(ACCESSIBILITY) is True
+        assert cache.is_enough_cached_data_present(ACCESSIBILITY) is True
 
 
 """
@@ -68,11 +51,11 @@ def test_is_enough_cached_data_present(cache_manager: CacheManager):
 """
 
 
-def test_convert_cached_data(cache_manager: CacheManager):
+def test_convert_cached_data(cache: CacheManager):
     meta_data = []
     feature = ACCESSIBILITY
 
-    empty_cache = cache_manager.convert_cached_data(meta_data, feature)
+    empty_cache = cache.convert_cached_data(meta_data, feature)
     assert empty_cache[EXPLANATION] == [Explanation.Cached]
     assert empty_cache[STAR_CASE] == StarCase.ONE
     assert empty_cache[VALUES] == []
@@ -83,7 +66,7 @@ def test_convert_cached_data(cache_manager: CacheManager):
         f'"{TIMESTAMP}": {get_utc_now()}}}'
     ]
 
-    cache_output = cache_manager.convert_cached_data(meta_data, feature)
+    cache_output = cache.convert_cached_data(meta_data, feature)
     assert isinstance(cache_output, dict)
     assert len(cache_output.keys()) == 3
     assert cache_output[EXPLANATION] == [
@@ -99,7 +82,7 @@ def test_convert_cached_data(cache_manager: CacheManager):
         f'"{TIMESTAMP}": {get_utc_now()}}}'
     ]
 
-    cache_output = cache_manager.convert_cached_data(meta_data, feature)
+    cache_output = cache.convert_cached_data(meta_data, feature)
     assert cache_output[STAR_CASE] == StarCase.ONE
 
     meta_data = [
@@ -108,7 +91,7 @@ def test_convert_cached_data(cache_manager: CacheManager):
         f'"{TIMESTAMP}": {get_utc_now()}}}'
     ]
 
-    cache_output = cache_manager.convert_cached_data(meta_data, feature)
+    cache_output = cache.convert_cached_data(meta_data, feature)
     assert cache_output[VALUES] == [0.9]
     assert cache_output[EXPLANATION] == [
         Explanation.Cached,
@@ -121,7 +104,7 @@ def test_convert_cached_data(cache_manager: CacheManager):
         f'"{TIMESTAMP}": {get_utc_now()}}}'
     ]
 
-    cache_output = cache_manager.convert_cached_data(meta_data, feature)
+    cache_output = cache.convert_cached_data(meta_data, feature)
     assert cache_output[STAR_CASE] == StarCase.FIVE
 
 
@@ -130,11 +113,11 @@ def test_convert_cached_data(cache_manager: CacheManager):
 """
 
 
-def test_get_predefined_metadata(mocker, cache_manager: CacheManager):
+def test_get_predefined_metadata(mocker, cache: CacheManager):
     meta_data = []
     feature = ACCESSIBILITY
 
-    empty_cache = cache_manager.convert_cached_data(meta_data, feature)
+    empty_cache = cache.convert_cached_data(meta_data, feature)
     assert empty_cache[EXPLANATION] == [Explanation.Cached]
     assert empty_cache[STAR_CASE] == StarCase.ONE
     assert empty_cache[VALUES] == []
@@ -145,9 +128,9 @@ def test_get_predefined_metadata(mocker, cache_manager: CacheManager):
     )
 
     with mock.patch("cache.cache_manager.read_cached_values_by_feature"):
-        cache_manager.convert_cached_data = mocker.MagicMock()
-        cache_manager.convert_cached_data.return_value = json.loads(meta_data)
-        cache_output = cache_manager.get_predefined_metadata(feature)
+        cache.convert_cached_data = mocker.MagicMock()
+        cache.convert_cached_data.return_value = json.loads(meta_data)
+        cache_output = cache.get_predefined_metadata(feature)
 
     assert isinstance(cache_output, dict)
     assert len(cache_output.keys()) == 1

--- a/tests/unit/metadata_manager_test.py
+++ b/tests/unit/metadata_manager_test.py
@@ -22,8 +22,7 @@ from tests.integration.features_integration_test import mock_website_data
 
 @pytest.fixture
 def metadata_manager():
-    manager = MetadataManager.get_instance()
-    return manager
+    return MetadataManager()
 
 
 """

--- a/tests/unit/metadata_manager_test.py
+++ b/tests/unit/metadata_manager_test.py
@@ -4,6 +4,7 @@ import os
 from logging import Logger
 from pathlib import Path
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
@@ -51,12 +52,6 @@ def test_is_feature_whitelisted_for_cache(mocker, metadata_manager: MetadataMana
 """
 
 
-def get_cache_manager():
-    with mock.patch("cache.cache_manager.get_logger"):
-        with mock.patch("cache.cache_manager.CacheManager._class._prepare_cache_manager"):
-            return CacheManager.get_instance()
-
-
 def test_cache_data(metadata_manager: MetadataManager):
     meta_data = {
         ACCESSIBILITY: {
@@ -65,11 +60,9 @@ def test_cache_data(metadata_manager: MetadataManager):
             STAR_CASE: StarCase.ONE,
         }
     }
-    allow_list = {ACCESSIBILITY: True}
-    cache_manager = get_cache_manager()
 
     with mock.patch("core.metadata_manager.create_cache_entry") as create_cache_entry:
-        metadata_manager.cache_data(meta_data, cache_manager, allow_list)
+        metadata_manager.cache_data(meta_data, allow_list=[ACCESSIBILITY])
         assert create_cache_entry.call_args[0][2][VALUES] == []
         assert create_cache_entry.call_count == 1
 
@@ -86,7 +79,7 @@ def test_cache_data(metadata_manager: MetadataManager):
 def test_extract_meta_data(metadata_manager: MetadataManager):
     paywall = "paywall"
     allow_list = ["accessibility", "paywall"]
-    cache_manager = get_cache_manager()
+    cache_manager = metadata_manager.cache_manager
 
     extractor_backup = metadata_manager.metadata_extractors
     metadata_manager.metadata_extractors = [
@@ -147,7 +140,7 @@ def test_extract_meta_data(metadata_manager: MetadataManager):
 
 
 def test_start(metadata_manager: MetadataManager):
-    cache_manager = get_cache_manager()
+    cache_manager = metadata_manager.cache_manager
 
     cache_manager._hosts = []
     cache_manager.domain = "google.com"
@@ -167,8 +160,8 @@ def test_start(metadata_manager: MetadataManager):
         return 0.98
 
     with mock.patch("core.metadata_manager.shared_memory.ShareableList") as shareable_list:
-        with mock.patch("cache.cache_manager.CacheManager._class.update_to_current_domain"):
-            with mock.patch("core.metadata_manager.MetadataManager._class.cache_data"):
+        with patch.object(cache_manager, "update_to_current_domain", return_value=None):
+            with patch.object(metadata_manager, "cache_data", return_value=None):
                 # intercept the request to the non-running splash
                 # container and lighthouse container
                 # and instead use the checked in response json and a hardcoded


### PR DESCRIPTION
The pattern wasn't really needed and obfuscated ownership of objects. It also may cause really hard to find bugs in a concurrent async environment, especially if the singleton methods are not reentrant. 

To avoid that we can simply remove it entirely to prevent any such issues in the future

- Resolves #91