### PR TITLE
Concurrent lighthouse service allowing multiple parallel requests

### DIFF
--- a/dockerfile_lighthouse
+++ b/dockerfile_lighthouse
@@ -33,7 +33,5 @@ ENV CHROME_FLAGS="--headless --disable-gpu --no-sandbox"
 WORKDIR /home/chrome
 
 COPY src/lighthouse/api.py .
-COPY src/lib/constants.py lib/
-COPY src/lib/settings.py lib/
 
 CMD python3 api.py


### PR DESCRIPTION
This should avoid `_ping` endpoint timeouts (if there were any) while the fastapi service is waiting for lighthouse completion.
Also the `--disable-dev-shm-usage` chrome flag should avoid `PROTOCOL_TIMEOUTS` caused by insufficient memory in `/dev/shm` from within the docker container.