### PR TITLE
use HttpUrl instead of str in cache warmup and lighthouse api data model

### DIFF
--- a/src/lighthouse/api.py
+++ b/src/lighthouse/api.py
@@ -8,7 +8,7 @@ from typing import List
 import pydantic
 import uvicorn as uvicorn
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, HttpUrl
 
 # the timeout that lighthouse internally uses when loading the website
 LOAD_TIMEOUT = int(os.environ.get("LOAD_TIMEOUT", 120))
@@ -30,7 +30,7 @@ class Output(BaseModel):
 
 
 class Input(BaseModel):
-    url: str = Field(..., description="The base url of the scraped website.")
+    url: HttpUrl = Field(..., description="The base url of the scraped website.")
     strategy: str = Field(
         default=_DESKTOP,
         description=f"Whether to use {_MOBILE} or {_DESKTOP}.",

--- a/src/metalookup/app/api.py
+++ b/src/metalookup/app/api.py
@@ -7,6 +7,7 @@ from typing import Optional
 from aiohttp import ClientSession
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import HttpUrl
 
 import metalookup.lib.settings
 from metalookup.app.models import Input, MetadataTags, Output, Ping
@@ -90,7 +91,7 @@ if metalookup.lib.settings.ENABLE_CACHE_CONTROL_ENDPOINTS:
     process: Optional[Process] = None
 
     # Note: needs to be in global context to be pickleable in order to be transferable to other process.
-    def _loop_urls(urls: list[str]):
+    def _loop_urls(urls: list[HttpUrl]):
         async def loop():
             logging.info(f"Starting cache warmup with {len(urls)} urls")
             async with ClientSession() as session:
@@ -112,7 +113,7 @@ if metalookup.lib.settings.ENABLE_CACHE_CONTROL_ENDPOINTS:
         is running, other requests to this endpoint will be answered with a 429 (Too many requests).
         """,
     )
-    async def warmup(urls: list[str], response: Response):
+    async def warmup(urls: list[HttpUrl], response: Response):
         global process
         logger.info("Received cache-warmup request - dispatching background process")
 


### PR DESCRIPTION
Minimal change that rejects any invalid input already on the API layer.

 - resolves #115 (the problem is essentially moved to the caller following the fail-fast paradigm)
 - partially resolves  #116 