### PR TITLE
fix request type for accessibility container

### DIFF
--- a/meta-lookup-compose-prod.yml
+++ b/meta-lookup-compose-prod.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "5057:5057"
     links:
-      - splash
+      - playwright
       - lighthouse
       - postgres
     depends_on:

--- a/src/metalookup/features/accessibility.py
+++ b/src/metalookup/features/accessibility.py
@@ -83,7 +83,7 @@ class Accessibility(Extractor[AccessibilityScores]):
         }
         try:
             with runtime() as t:
-                response = await session.get(
+                response = await session.post(
                     url=f"{self.lighthouse_url}/{_ACCESSIBILITY}", timeout=self.lighthouse_timeout, json=params
                 )
             logger.debug(f"Fetched accessibility for {strategy} in {t():5.2f}s")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def lighthouse_mock(score: float = 0.98, status=200, detail: Optional[str] = Non
 
         return Mock(status=status, json=json)
 
-    with mock.patch("aiohttp.ClientSession.get", client_mock):
+    with mock.patch("aiohttp.ClientSession.post", client_mock):
         yield
 
 


### PR DESCRIPTION
At some point I change the method from GET to POST of the accessibility container - But never updated the respective client side. That worked well locally, because I never rebuild the accessibility container.